### PR TITLE
Updating Laravel requirements to include 5.7-5.8 and no higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "api-wrapper", "igdb", "igdb-api", "apicalypse", "wrapper"],
     "require": {
         "php": "^7.1.3",
-        "laravel/framework": ">=5.7.* <=5.8.*",
+        "laravel/framework": ">=5.7 <=5.8",
         "guzzlehttp/guzzle": "~6.0",
         "ext-json": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "api-wrapper", "igdb", "igdb-api", "apicalypse", "wrapper"],
     "require": {
         "php": "^7.1.3",
-        "laravel/framework": "5.7.*",
+        "laravel/framework": ">=5.7.* <=5.8.*",
         "guzzlehttp/guzzle": "~6.0",
         "ext-json": "*"
     },


### PR DESCRIPTION
Updating Laravel requirements to include 5.7-5.8 and no higher in case there are revisions to a future release that break things. It should be noted that cache times are measured in seconds and not minutes starting with 5.8.