### PR TITLE
Using an OR statement to specify 5.7.* and 5.8.* support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "api-wrapper", "igdb", "igdb-api", "apicalypse", "wrapper"],
     "require": {
         "php": "^7.1.3",
-        "laravel/framework": ">=5.7 <=5.8",
+        "laravel/framework": "5.7.*|5.8.*",
         "guzzlehttp/guzzle": "~6.0",
         "ext-json": "*"
     },


### PR DESCRIPTION
This should clear up install issues for 5.8 folks (hopefully) The ranged values I used before were exclusionary from the version number which made the 5.8 install impossible.