### PR TITLE
Add Arrayable and Jsonable interface to model.

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -2,15 +2,17 @@
 
 namespace MarcReichel\IGDBLaravel\Models;
 
-use Carbon\Carbon;
 use Error;
+use Carbon\Carbon;
 use BadMethodCallException;
 use Illuminate\Support\Str;
 use MarcReichel\IGDBLaravel\Builder;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 use MarcReichel\IGDBLaravel\Traits\HasAttributes;
 use MarcReichel\IGDBLaravel\Traits\HasRelationships;
 
-class Model
+class Model implements Arrayable, Jsonable
 {
     use HasAttributes,
         HasRelationships;
@@ -266,6 +268,8 @@ class Model
     }
 
     /**
+     * Get the instance as an array.
+     *
      * @return array
      */
     public function toArray(): array
@@ -283,19 +287,13 @@ class Model
     }
 
     /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
      * @return string
      */
-    public function toJson(): string
+    public function toJson($options = 0): string
     {
-        $attributes = collect($this->attributes);
-        $relations = collect($this->relations)->map(function($relation) {
-            if (is_array($relation)) {
-                return collect($relation)->map(function($single) {
-                    return $single->toJson();
-                })->toJson();
-            }
-            return $relation->toJson();
-        });
-        return $attributes->merge($relations)->sortKeys()->toJson();
+        return collect($this->toArray())->toJson($options);
     }
 }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -276,12 +276,10 @@ class Model implements Arrayable, Jsonable
     {
         $attributes = collect($this->attributes);
         $relations = collect($this->relations)->map(function($relation) {
-            if (is_array($relation)) {
-                return collect($relation)->map(function($single) {
-                    return $single->toArray();
-                })->toArray();
+            if($relation instanceof Arrayable){
+                return $relation->toArray();
             }
-            return $relation->toArray();
+            return $relation;
         });
         return $attributes->merge($relations)->sortKeys()->toArray();
     }


### PR DESCRIPTION
Add Arrayable and Jsonable interface to model to more easily allow Collections to convert models to arrays or json.

Changes made to toJson method to reduce code duplication. Current code is basically the same as toArray method, but toJson is called instead. 

Changes made to toArray method. Closure that maps over the related model collection now checks if the relation implements Arrayable before trying to call toArray method.