### PR TITLE
Relations and ArrayAccess

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -121,7 +121,7 @@ class Model implements Arrayable, Jsonable
                     })->toArray();
                 }
                 return $this->mapToModel($key, $value);
-            })->toArray();
+            });
     }
 
     /**

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -185,7 +185,7 @@ class Model implements ArrayAccess, Arrayable, Jsonable
                 if (is_array($value)) {
                     return collect($value)->map(function($value) use ($key) {
                         return $this->mapToModel($key, $value);
-                    })->toArray();
+                    });
                 }
                 return $this->mapToModel($key, $value);
             });

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -3,6 +3,7 @@
 namespace MarcReichel\IGDBLaravel\Models;
 
 use Error;
+use ArrayAccess;
 use Carbon\Carbon;
 use BadMethodCallException;
 use Illuminate\Support\Str;
@@ -12,7 +13,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use MarcReichel\IGDBLaravel\Traits\HasAttributes;
 use MarcReichel\IGDBLaravel\Traits\HasRelationships;
 
-class Model implements Arrayable, Jsonable
+class Model implements ArrayAccess, Arrayable, Jsonable
 {
     use HasAttributes,
         HasRelationships;
@@ -51,6 +52,72 @@ class Model implements Arrayable, Jsonable
         return $this->getAttribute($field);
     }
 
+    /**
+     * @param $field
+     *
+     * @param $value
+     */
+    public function __set($field, $value)
+    {
+        $this->attributes[$field] = $value;
+    }
+
+    /**
+     * @param mixed $field
+     *
+     * @return bool
+     */
+    public function offsetExists($field)
+    {
+        return isset($this->attributes[$field]) || isset($this->relations[$field]);
+    }
+
+    /**
+     * @param mixed $field
+     *
+     * @return mixed
+     */
+    public function offsetGet($field)
+    {
+        return $this->getAttribute($field);
+    }
+
+    /**
+     * @param mixed $field
+     *
+     * @return mixed
+     */
+    public function offsetSet($field, $value)
+    {
+        $this->attributes[$field] = $value;
+    }
+
+    /**
+     * @param mixed $field
+     */
+    public function offsetUnset($field)
+    {
+        unset($this->attributes[$field], $this->relations[$field]);
+    }
+
+    /**
+     * @param $field
+     *
+     * @return bool
+     */
+    public function __isset($field)
+    {
+        return $this->offsetExists($field);
+    }
+
+    /**
+     * @param $field
+     */
+    public function __unset($field)
+    {
+        $this->offsetUnset($field);
+    }
+    
     /**
      * @param $method
      * @param $parameters


### PR DESCRIPTION
1. Fixed the model relations by removing a "toArray" call (it converted all related models into arrays instead of keeping them as their own respective objects).
2. Added ArrayAcces to the Model class so the fix above doesn't break any current implementations already using the relations as arrays.