### PR TITLE
Laravel 8.0 and Guzzle 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "keywords": ["laravel", "api-wrapper", "igdb", "igdb-api", "apicalypse", "wrapper"],
     "require": {
         "php": "^7.2.5",
-        "laravel/framework": "5.8.*|^6.0|^7.0",
-        "guzzlehttp/guzzle": "~6.0",
+        "laravel/framework": "5.8.*|^6.0|^7.0|^8.0",
+        "guzzlehttp/guzzle": "~6.0|~7.0",
         "ext-json": "*"
     },
     "license": "MIT",


### PR DESCRIPTION
Laravel 8.0 was released. This adds support for it and Guzzle.