### PR TITLE
Fix count method

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1580,7 +1580,7 @@ class Builder
                                     'Authorization' => 'Bearer '.$accessToken,
                                 ],
                                 'body' => $this->getQuery(),
-                            ])->getBody())['count'];
+                            ])->getBody(), true)['count'];
                     } catch (\Exception $exception) {
                         $this->handleRequestException($exception);
                     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1555,7 +1555,7 @@ class Builder
 
     /**
      * @return mixed
-     * @throws \MarcReichel\IGDBLaravel\Exceptions\MissingEndpointException
+     * @throws \MarcReichel\IGDBLaravel\Exceptions\MissingEndpointException|AuthenticationException
      */
     public function count()
     {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1574,7 +1574,7 @@ class Builder
             $data = Cache::remember($cacheKey, $this->cacheLifetime,
                 function () use ($accessToken) {
                     try {
-                        return (int)json_decode($this->client->get($this->endpoint,
+                        return (int)json_decode($this->client->post($this->endpoint,
                             [
                                 'headers' => [
                                     'Authorization' => 'Bearer '.$accessToken,

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1554,6 +1554,8 @@ class Builder
     }
 
     /**
+     * Return the total "count" result of the query.
+     *
      * @return mixed
      * @throws \MarcReichel\IGDBLaravel\Exceptions\MissingEndpointException|AuthenticationException
      */

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1559,6 +1559,8 @@ class Builder
      */
     public function count()
     {
+        $accessToken = $this->retrieveAccessToken();
+
         if ($this->endpoint) {
 
             $this->endpoint = Str::finish($this->endpoint, '/') . 'count';
@@ -1570,10 +1572,13 @@ class Builder
             }
 
             $data = Cache::remember($cacheKey, $this->cacheLifetime,
-                function () {
+                function () use ($accessToken) {
                     try {
                         return (int)json_decode($this->client->get($this->endpoint,
                             [
+                                'headers' => [
+                                    'Authorization' => 'Bearer '.$accessToken,
+                                ],
                                 'body' => $this->getQuery(),
                             ])->getBody())['count'];
                     } catch (\Exception $exception) {


### PR DESCRIPTION
This PR fixes the `count()` method for API version 4. (Should fix first issue in #23)

- Retrieves and uses the access token
- Changes the method to post
- Updates docblock
- `json_decode` was returning an object, rather than array