### PR TITLE
Implementation PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "phpunit/phpunit": "^9.5.4",
     "orchestra/testbench": "^6.0",
     "nunomaduro/collision": "^5.3",
-    "roave/security-advisories": "dev-latest"
+    "roave/security-advisories": "dev-latest",
+    "nunomaduro/larastan": "^0.7.13"
   },
   "license": "MIT",
   "authors": [
@@ -30,7 +31,9 @@
     }
   ],
   "scripts": {
-    "test": "./vendor/bin/testbench package:test"
+    "test": "./vendor/bin/testbench package:test",
+    "stan": "./vendor/bin/phpstan analyse -c phpstan.neon",
+    "stan-2g": "./vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=2G"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,16 @@
+includes:
+  - ./vendor/nunomaduro/larastan/extension.neon
+
+parameters:
+  paths:
+    - src
+    - tests
+
+  # The level 8 is the highest level
+  level: 8
+  ignoreErrors:
+    - '#Attribute class JetBrains\\PhpStorm\\ArrayShape does not exist.#'
+    # - '#Unsafe usage of new static#'
+  excludePaths:
+    # - ./*/*/FileToBeExcluded.php
+  checkMissingIterableValueType: false

--- a/src/ApiHelper.php
+++ b/src/ApiHelper.php
@@ -39,12 +39,12 @@ class ApiHelper
             if (isset($response['access_token']) && $response['expires_in']) {
                 Cache::put($accessTokenCacheKey, (string)$response['access_token'], (int)$response['expires_in']);
 
-                $accessToken = (string)$response['access_token'];
+                $accessToken = $response['access_token'];
             }
         } catch (Exception) {
             throw new AuthenticationException('Access Token could not be retrieved from Twitch.');
         }
 
-        return $accessToken;
+        return (string) $accessToken;
     }
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -61,11 +61,11 @@ class Builder
     /**
      * Builder constructor.
      *
-     * @param $model
+     * @param mixed $model
      *
      * @throws ReflectionException
      */
-    public function __construct($model = null)
+    public function __construct(mixed $model = null)
     {
         if ($model) {
             $this->setEndpoint($model);
@@ -463,9 +463,16 @@ class Builder
     }
 
     /**
+     * @param  string  $key
+     * @param  string  $value
+     * @param  bool    $caseSensitive
+     * @param  string  $operator
+     * @param  string  $insensitiveOperator
+     *
+     * @return string
      * @throws JsonException
      */
-    private function generateWhereLikeClause($key, $value, $caseSensitive, $operator, $insensitiveOperator): string
+    private function generateWhereLikeClause(string $key, string $value, bool $caseSensitive, string $operator, string $insensitiveOperator): string
     {
         $hasPrefix = Str::startsWith($value, ['%', '*']);
         $hasSuffix = Str::endsWith($value, ['%', '*']);
@@ -580,12 +587,12 @@ class Builder
     /**
      * Add another query builder as a nested where to the query builder.
      *
-     * @param $query
-     * @param $boolean
+     * @param Builder $query
+     * @param string $boolean
      *
      * @return self
      */
-    protected function addNestedWhereQuery($query, $boolean): self
+    protected function addNestedWhereQuery(Builder $query, string $boolean): self
     {
         $where = $this->query->get('where', new Collection());
 
@@ -903,19 +910,19 @@ class Builder
     /**
      * Add a where between statement to the query.
      *
-     * @param string $key
-     * @param        $first
-     * @param        $second
-     * @param bool   $withBoundaries
-     * @param string $boolean
+     * @param  string  $key
+     * @param  mixed   $first
+     * @param  mixed   $second
+     * @param  bool    $withBoundaries
+     * @param  string  $boolean
      *
      * @return self
      * @throws ReflectionException
      */
     public function whereBetween(
         string $key,
-        $first,
-        $second,
+        mixed $first,
+        mixed $second,
         bool $withBoundaries = true,
         string $boolean = '&'
     ): self {
@@ -941,19 +948,19 @@ class Builder
     /**
      * Add a or where between statement to the query.
      *
-     * @param string $key
-     * @param        $first
-     * @param        $second
-     * @param bool   $withBoundaries
-     * @param string $boolean
+     * @param  string  $key
+     * @param  mixed   $first
+     * @param  mixed   $second
+     * @param  bool    $withBoundaries
+     * @param  string  $boolean
      *
      * @return self
      * @throws ReflectionException
      */
     public function orWhereBetween(
         string $key,
-        $first,
-        $second,
+        mixed $first,
+        mixed $second,
         bool $withBoundaries = true,
         string $boolean = '|'
     ): self {
@@ -964,19 +971,19 @@ class Builder
     /**
      * Add a where not between statement to the query.
      *
-     * @param string $key
-     * @param        $first
-     * @param        $second
-     * @param bool   $withBoundaries
-     * @param string $boolean
+     * @param  string  $key
+     * @param  mixed   $first
+     * @param  mixed   $second
+     * @param  bool    $withBoundaries
+     * @param  string  $boolean
      *
      * @return self
      * @throws ReflectionException
      */
     public function whereNotBetween(
         string $key,
-        $first,
-        $second,
+        mixed $first,
+        mixed $second,
         bool $withBoundaries = false,
         string $boolean = '&'
     ): self {
@@ -1002,19 +1009,19 @@ class Builder
     /**
      * Add a or where not between statement to the query.
      *
-     * @param string $key
-     * @param        $first
-     * @param        $second
-     * @param bool   $withBoundaries
-     * @param string $boolean
+     * @param  string  $key
+     * @param  mixed   $first
+     * @param  mixed   $second
+     * @param  bool    $withBoundaries
+     * @param  string  $boolean
      *
      * @return self
      * @throws ReflectionException
      */
     public function orWhereNotBetween(
         string $key,
-        $first,
-        $second,
+        mixed $first,
+        mixed $second,
         bool $withBoundaries = false,
         string $boolean = '|'
     ): self {
@@ -1172,16 +1179,16 @@ class Builder
     }
 
     /**
-     * @param $key
-     * @param $operator
-     * @param $value
-     * @param $boolean
+     * @param  string  $key
+     * @param  mixed   $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
      *
-     * @return Builder
+     * @return self
      * @throws JsonException
      * @throws ReflectionException
      */
-    private function whereDateGreaterThan($key, $operator, $value, $boolean): Builder
+    private function whereDateGreaterThan(string $key, mixed $operator, mixed $value, string $boolean): self
     {
         $value = Carbon::parse($value)->addDay()->startOfDay()->timestamp;
 
@@ -1189,16 +1196,16 @@ class Builder
     }
 
     /**
-     * @param $key
-     * @param $operator
-     * @param $value
-     * @param $boolean
+     * @param  string  $key
+     * @param  mixed   $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
      *
-     * @return $this
+     * @return self
      * @throws JsonException
      * @throws ReflectionException
      */
-    private function whereDateGreaterThanOrEquals($key, $operator, $value, $boolean): Builder
+    private function whereDateGreaterThanOrEquals(string $key, mixed $operator, mixed $value, string $boolean): self
     {
         $value = Carbon::parse($value)->startOfDay()->timestamp;
 
@@ -1206,16 +1213,16 @@ class Builder
     }
 
     /**
-     * @param $key
-     * @param $operator
-     * @param $value
-     * @param $boolean
+     * @param  string  $key
+     * @param  mixed   $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
      *
-     * @return $this
+     * @return self
      * @throws JsonException
      * @throws ReflectionException
      */
-    private function whereDateLowerThan($key, $operator, $value, $boolean): Builder
+    private function whereDateLowerThan(string $key, mixed $operator, mixed $value, string $boolean): self
     {
         $value = Carbon::parse($value)->subDay()->endOfDay()->timestamp;
 
@@ -1223,16 +1230,16 @@ class Builder
     }
 
     /**
-     * @param $key
-     * @param $operator
-     * @param $value
-     * @param $boolean
+     * @param  string  $key
+     * @param  mixed   $operator
+     * @param  mixed   $value
+     * @param  string  $boolean
      *
-     * @return $this
+     * @return self
      * @throws JsonException
      * @throws ReflectionException
      */
-    private function whereDateLowerThanOrEquals($key, $operator, $value, $boolean): Builder
+    private function whereDateLowerThanOrEquals(string $key, mixed $operator, mixed $value, string $boolean): self
     {
         $value = Carbon::parse($value)->endOfDay()->timestamp;
 
@@ -1271,28 +1278,25 @@ class Builder
         [$value, $operator] = $this->prepareValueAndOperator($value, $operator,
             func_num_args() === 2);
 
+        $value = Carbon::create($value);
+
+        if (is_bool($value)) {
+            throw new InvalidArgumentException('Could not convert value to Creator.');
+        }
+
         if ($operator === '=') {
-            $start = Carbon::create($value)->startOfYear()->timestamp;
-            $end = Carbon::create($value)->endOfYear()->timestamp;
+            $start = $value->startOfYear()->timestamp;
+            $end = $value->endOfYear()->timestamp;
 
             return $this->whereBetween($key, $start, $end, true, $boolean);
         }
 
-        if ($operator === '>') {
-            $value = Carbon::create($value)->endOfYear()->timestamp;
+        if ($operator === '>' || $operator === '<=') {
+            $value = $value->endOfYear()->timestamp;
+        } elseif ($operator === '>=' || $operator === '<') {
+            $value = $value->startOfYear()->timestamp;
         }
 
-        if ($operator === '>=') {
-            $value = Carbon::create($value)->startOfYear()->timestamp;
-        }
-
-        if ($operator === '<') {
-            $value = Carbon::create($value)->startOfYear()->timestamp;
-        }
-
-        if ($operator === '<=') {
-            $value = Carbon::create($value)->endOfYear()->timestamp;
-        }
 
         return $this->where($key, $operator, $value, $boolean);
     }
@@ -1440,12 +1444,13 @@ class Builder
     /**
      * Set the endpoint from model or string
      *
-     * @param $model
+     * @param  mixed  $model
      *
      * @return void
      * @throws ReflectionException
+     * @throws InvalidParamsException
      */
-    protected function setEndpoint($model): void
+    protected function setEndpoint(mixed $model): void
     {
         $neededNamespace = __NAMESPACE__ . '\\Models';
 
@@ -1455,6 +1460,10 @@ class Builder
 
             if ($parents->isEmpty()) {
                 $parents->push($class);
+            }
+
+            if (is_null($parents->last()) || is_bool($parents->last())) {
+                throw new InvalidParamsException('Last parent element is either null or false. String or {} required.');
             }
 
             $reflectionClass = new ReflectionClass($parents->last());
@@ -1469,7 +1478,7 @@ class Builder
             $this->endpoint = $model;
         }
 
-        if ($this->endpoint === null) {
+        if (!isset($this->endpoint)) {
             $message = 'Construction-Parameter of Builder must be a string or a Class which extends ' . $neededNamespace . '\\Model. ' . ucfirst(gettype($model)) . ' given.';
             throw new InvalidArgumentException($message);
         }
@@ -1478,11 +1487,11 @@ class Builder
     /**
      * Cast a value as date.
      *
-     * @param $date
+     * @param  mixed  $date
      *
-     * @return int
+     * @return float|int|string
      */
-    private function castDate($date): int
+    private function castDate(mixed $date): float|int|string
     {
         if (!is_numeric($date)) {
             return Carbon::parse((string)$date)->timestamp;
@@ -1512,11 +1521,11 @@ class Builder
     }
 
     /**
-     * @param $result
+     * @param  mixed  $result
      *
      * @return mixed
      */
-    private function mapToModel($result): mixed
+    private function mapToModel(mixed $result): mixed
     {
         $model = $this->class;
 

--- a/src/Console/CreateWebhook.php
+++ b/src/Console/CreateWebhook.php
@@ -3,6 +3,7 @@
 namespace MarcReichel\IGDBLaravel\Console;
 
 use Illuminate\Console\Command;
+use InvalidArgumentException;
 use MarcReichel\IGDBLaravel\Exceptions\AuthenticationException;
 use MarcReichel\IGDBLaravel\Exceptions\InvalidWebhookMethodException;
 use MarcReichel\IGDBLaravel\Exceptions\WebhookSecretMissingException;
@@ -10,10 +11,19 @@ use MarcReichel\IGDBLaravel\Models\Model;
 
 class CreateWebhook extends Command
 {
+    /**
+     * @var string
+     */
     protected $signature = 'igdb:webhooks:create {model?} {--method=}';
 
+    /**
+     * @var string
+     */
     protected $description = 'Create a webhook at IGDB.';
 
+    /**
+     * @return int
+     */
     public function handle(): int
     {
         $modelQuestionString = 'For which model you want to create a webhook?';
@@ -21,7 +31,7 @@ class CreateWebhook extends Command
         $model = $this->argument('model') ?? $this->choice($modelQuestionString, $this->getModels());
 
         if (!is_string($model)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Argument <comment>model</comment> has to be of type string. ' . gettype($model) . ' given.',
             );
         }
@@ -73,6 +83,10 @@ class CreateWebhook extends Command
     {
         $pattern = '/\/(?:Model|Search|Webhook)\.php$/';
         $glob = glob(__DIR__ . '/../Models/*.php');
+
+        if (!$glob) {
+            return [];
+        }
 
         return collect(preg_grep($pattern, $glob, PREG_GREP_INVERT))
             ->map(function ($path) {

--- a/src/Console/DeleteWebhook.php
+++ b/src/Console/DeleteWebhook.php
@@ -7,13 +7,22 @@ use MarcReichel\IGDBLaravel\Models\Webhook;
 
 class DeleteWebhook extends Command
 {
+    /**
+     * @var string
+     */
     protected $signature = 'igdb:webhooks:delete {id?} {--A|all}';
 
+    /**
+     * @var string
+     */
     protected $description = 'Delete a webhook at IGDB.';
 
+    /**
+     * @return int
+     */
     public function handle(): int
     {
-        $id = $this->argument('id');
+        $id = (int)$this->argument('id');
 
         if ($id) {
             return $this->deleteOne($id);
@@ -27,13 +36,12 @@ class DeleteWebhook extends Command
     }
 
     /**
-     * @param $id
+     * @param  int  $id
      *
      * @return int
      */
-    private function deleteOne($id): int
+    private function deleteOne(int $id): int
     {
-        /** @var Webhook $webhook */
         $webhook = Webhook::find($id);
 
         if (!$webhook) {

--- a/src/Console/ReactivateWebhook.php
+++ b/src/Console/ReactivateWebhook.php
@@ -11,14 +11,23 @@ use MarcReichel\IGDBLaravel\Models\Webhook;
 
 class ReactivateWebhook extends Command
 {
+    /**
+     * @var string
+     */
     protected $signature = 'igdb:webhooks:reactivate {id}';
 
+    /**
+     * @var string
+     */
     protected $description = 'Reactivate an inactive webhook.';
 
+    /**
+     * @return int
+     */
     public function handle(): int
     {
         /** @var Webhook|null $webhook */
-        $webhook = Webhook::find($this->argument('id'));
+        $webhook = Webhook::find((int) $this->argument('id'));
 
         if (!$webhook) {
             $this->error('Webhook not found.');

--- a/src/Exceptions/InvalidWebhookSecretException.php
+++ b/src/Exceptions/InvalidWebhookSecretException.php
@@ -6,5 +6,8 @@ use Exception;
 
 class InvalidWebhookSecretException extends Exception
 {
+    /**
+     * @var string
+     */
     protected $message = 'Invalid secret provided';
 }

--- a/src/Exceptions/MissingEndpointException.php
+++ b/src/Exceptions/MissingEndpointException.php
@@ -6,5 +6,8 @@ use Exception;
 
 class MissingEndpointException extends Exception
 {
+    /**
+     * @var string
+     */
     protected $message = 'Please provide an endpoint.';
 }

--- a/src/Exceptions/WebhookSecretMissingException.php
+++ b/src/Exceptions/WebhookSecretMissingException.php
@@ -6,5 +6,8 @@ use Exception;
 
 class WebhookSecretMissingException extends Exception
 {
+    /**
+     * @var string
+     */
     protected $message = 'Webhook secret is missing. Please provide one in your `igdb.php` config file.';
 }

--- a/src/Interfaces/ModelInterface.php
+++ b/src/Interfaces/ModelInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MarcReichel\IGDBLaravel\Interfaces;
+
+interface ModelInterface
+{
+    /**
+     * @param  array  $properties
+     */
+    public function __construct(array $properties = []);
+}

--- a/src/Interfaces/WebhookInterface.php
+++ b/src/Interfaces/WebhookInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MarcReichel\IGDBLaravel\Interfaces;
+
+interface WebhookInterface
+{
+    /**
+     * @param  mixed  ...$parameters
+     */
+    public function __construct(mixed ...$parameters);
+}

--- a/src/Models/AgeRating.php
+++ b/src/Models/AgeRating.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class AgeRating extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'content_descriptions' => AgeRatingContentDescription::class,
     ];

--- a/src/Models/Character.php
+++ b/src/Models/Character.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class Character extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'mug_shot' => CharacterMugShot::class,
     ];

--- a/src/Models/Company.php
+++ b/src/Models/Company.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class Company extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'changed_company_id' => self::class,
         'developed' => Game::class,

--- a/src/Models/Game.php
+++ b/src/Models/Game.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class Game extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'bundles' => self::class,
         'dlcs' => self::class,

--- a/src/Models/GameEngine.php
+++ b/src/Models/GameEngine.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class GameEngine extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'logo' => GameEngineLogo::class,
     ];

--- a/src/Models/GameVersionFeature.php
+++ b/src/Models/GameVersionFeature.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class GameVersionFeature extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'values' => GameVersionFeatureValue::class,
     ];

--- a/src/Models/GameVersionFeatureValue.php
+++ b/src/Models/GameVersionFeatureValue.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class GameVersionFeatureValue extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'game_feature' => GameVersionFeature::class,
     ];

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -17,6 +17,7 @@ use MarcReichel\IGDBLaravel\Enums\Webhook\Method;
 use MarcReichel\IGDBLaravel\Exceptions\AuthenticationException;
 use MarcReichel\IGDBLaravel\Exceptions\InvalidWebhookMethodException;
 use MarcReichel\IGDBLaravel\Exceptions\WebhookSecretMissingException;
+use MarcReichel\IGDBLaravel\Interfaces\ModelInterface;
 use ReflectionClass;
 use ReflectionException;
 
@@ -81,7 +82,7 @@ use ReflectionException;
  *
  * @package MarcReichel\IGDBLaravel\Models
  */
-abstract class Model implements ArrayAccess, Arrayable, Jsonable
+abstract class Model implements ModelInterface, ArrayAccess, Arrayable, Jsonable
 {
     use HasAttributes, HasRelationships;
 
@@ -111,11 +112,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable
     }
 
     /**
-     * @param $field
+     * @param mixed $field
      *
      * @return mixed
      */
-    public function __get($field)
+    public function __get(mixed $field): mixed
     {
         return $this->getAttribute($field);
     }
@@ -283,15 +284,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable
      * @param mixed $fields
      *
      * @return Model
-     * @throws ReflectionException
      */
     public function getInstance(mixed $fields): Model
     {
-        if (is_null(self::$instance)) {
-            $model = new static($fields);
-            self::$instance = $model;
-        }
-
         return self::$instance;
     }
 
@@ -350,7 +345,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable
         if (collect($this->casts)->has($property)) {
             $class = collect($this->casts)->get($property);
 
-            if (class_exists($class)) {
+            if (!is_null($class) && class_exists($class)) {
                 return $class;
             }
         }

--- a/src/Models/Platform.php
+++ b/src/Models/Platform.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class Platform extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'websites' => PlatformWebsite::class,
     ];

--- a/src/Models/PlatformVersion.php
+++ b/src/Models/PlatformVersion.php
@@ -4,6 +4,9 @@ namespace MarcReichel\IGDBLaravel\Models;
 
 class PlatformVersion extends Model
 {
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [
         'companies' => PlatformVersionCompany::class,
         'main_manufacturer' => PlatformVersionCompany::class,

--- a/src/Traits/HasAttributes.php
+++ b/src/Traits/HasAttributes.php
@@ -4,14 +4,25 @@ namespace MarcReichel\IGDBLaravel\Traits;
 
 trait HasAttributes
 {
+    /**
+     * @var array|string[]
+     */
     public array $attributes = [];
+
+    /**
+     * @var array|string[]
+     */
     protected array $casts = [];
+
+    /**
+     * @var array|string[]
+     */
     protected array $dates = [
         'created_at',
         'updated_at',
         'change_date',
         'start_date',
         'published_at',
-        'first_release_date'
+        'first_release_date',
     ];
 }

--- a/src/Traits/HasRelationships.php
+++ b/src/Traits/HasRelationships.php
@@ -6,5 +6,8 @@ use Illuminate\Support\Collection;
 
 trait HasRelationships
 {
+    /**
+     * @var Collection
+     */
     public Collection $relations;
 }

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -9,7 +9,10 @@ use MarcReichel\IGDBLaravel\Exceptions\InvalidParamsException;
 
 class BuilderTest extends TestCase
 {
-    private $igdb;
+    /**
+     * @var Builder $igdb
+     */
+    private Builder $igdb;
 
     public function setUp(): void
     {


### PR DESCRIPTION
This pull request does the following:

- Introducing Larastan to the project
- Implement shortcuts  to execute phpstan
- Fixed findings (Set all missing type hints and return types)

With this, we could possibly add PHPStan GitHub Actions and the badge if the test passed with the current selected branch or not.

If you are running a unix based system you can run the following to execute the shortcut:
`composer stan`  
  
If you are running windows you can run the following to execute the shortcut:
`composer stan-2g`
  
Only supports `PHP 8` or higher.