### PR TITLE
fix(website_category): Added Bluesky

### DIFF
--- a/src/Enums/Website/Category.php
+++ b/src/Enums/Website/Category.php
@@ -23,4 +23,5 @@ enum Category: int
     case EPIC_GAMES = 16;
     case GOG = 17;
     case DISCORD = 18;
+    case BLUESKY = 19;
 }


### PR DESCRIPTION
Added Bluesky = 19 to the website categories as it now appears in https://api.igdb.com/v4/website_types

```json
{
    "id": 19,
    "type": "Bluesky",
    "created_at": 1742385158,
    "updated_at": 1742385158,
    "checksum": "866442d1-5e23-4c9f-5d99-f1086091daa6"
}
```
