### PR TITLE
fix(website_category) Added Xbox, Playstation, Nintendo and Meta

### DIFF
--- a/src/Enums/Website/Category.php
+++ b/src/Enums/Website/Category.php
@@ -24,4 +24,8 @@ enum Category: int
     case GOG = 17;
     case DISCORD = 18;
     case BLUESKY = 19;
+    case XBOX = 22;
+    case PLAYSTATION = 23;
+    case NINTENDO = 24;
+    case META = 25;
 }


### PR DESCRIPTION
They have added even more categories.

Updated the enum to include them.

```json
{
    "id": 19,
    "type": "Bluesky",
    "created_at": 1742385158,
    "updated_at": 1742385158,
    "checksum": "866442d1-5e23-4c9f-5d99-f1086091daa6"
},
// the ids from their website_types endpoint does not return id 20 or 21
{
    "id": 22,
    "type": "Xbox",
    "created_at": 1746526709,
    "updated_at": 1746526709,
    "checksum": "7e8752e9-ad1f-fb67-2b61-be255a934e87"
},
{
    "id": 23,
    "type": "Playstation",
    "created_at": 1746526709,
    "updated_at": 1746526709,
    "checksum": "752b2f52-5858-c45b-8537-1fac3518fa60"
},
{
    "id": 24,
    "type": "Nintendo",
    "created_at": 1746526709,
    "updated_at": 1746526709,
    "checksum": "908985cc-c98a-9d55-217d-8ccf0de8803d"
},
{
    "id": 25,
    "type": "Meta",
    "created_at": 1746526709,
    "updated_at": 1746526709,
    "checksum": "fa3c5a52-e575-4fde-6b26-3db5dd075b96"
}
```